### PR TITLE
feat: Add merge or replace option when loading data

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -209,6 +209,16 @@ Aquesta versió introdueix una refactorització completa de la secció **"Fitxes
     *   Suport per a tema clar i fosc.
     *   Notificacions (toasts) per a les accions de l'usuari.
     *   Visualització detallada d'estats mixts.
+
+-   **✨ [NOU] Càrrega de Dades Flexible (Fusió o Reemplaçament):**
+    *   **Modal de Decisió:** En carregar un fitxer de **persones** o de **material**, ara es mostra un diàleg que pregunta a l'usuari si desitja **fusionar** les dades noves amb les existents o **reemplaçar** completament les dades actuals.
+    *   **Lògica de Fusió Intel·ligent:**
+        *   **Persones:** La fusió afegeix només les persones del fitxer que no existeixen a la llista actual (la comprovació es fa per nom, ignorant majúscules/minúscules).
+        *   **Material:** La fusió afegeix només els articles del fitxer que no existeixen a l'inventari actual (la comprovació es fa per nom, ignorant majúscules/minúscules).
+    *   **Arquitectura:**
+        *   **`MergeOrReplaceModal.tsx`**: Nou component de modal reutilitzable per a aquesta funcionalitat.
+        *   **`useEventDataManager.ts`**: S'han afegit les funcions `mergePeopleGroups`, `replacePeopleGroups`, i `replaceMaterialItems` per gestionar la lògica de dades. La funció `addMaterialItemsFromFile` es reutilitza per a la fusió de material.
+        *   **`Controls.tsx`**: Modificat per llegir el fitxer i obrir el modal amb les dades, en lloc d'executar l'acció directament.
 ---
 ## 🛠️ Pila Tecnològica (Tech Stack)
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Per ajudar-te a començar, hem inclòs una carpeta anomenada `examples json` amb
     *   ⚠️ **Atenció:** Aquesta acció **esborra totes les dades actuals** i les reemplaça amb el contingut del fitxer.
 
 *   **`example_person.json`**: Conté una llista de contactes. Es carrega amb el botó **`Carregar Persones`**.
-    *   ⚠️ **Atenció:** Aquesta acció **reemplaça completament** la teva llista de persones actual.
+    *   🆕 **Novetat:** En carregar, l'aplicació et preguntarà si vols **fusionar** la nova llista amb l'existent (afegint només les persones que no existeixin) o **reemplaçar** completament la llista actual.
 
 *   **`example_material.json`**: Un inventari de material d'exemple. Es carrega amb el botó **`Carregar Material`**.
-    *   ✅ Aquesta acció és segura: **afegeix els nous articles** del fitxer al teu inventari existent sense esborrar res.
+    *   🆕 **Novetat:** Igual que amb les persones, podràs triar entre **fusionar** l'inventari (afegint només els articles nous) o **reemplaçar-lo** per complet.
 
 ## ✒️ Autoria
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ const AssignmentFormModal = lazy(() => import('./components/modals/AssignmentFor
 const ConfirmDeleteModal = lazy(() => import('./components/modals/ConfirmDeleteModal'));
 const EventFrameDetailsModal = lazy(() => import('./components/modals/EventFrameDetailsModal'));
 const GoogleSettingsModal = lazy(() => import('./components/modals/GoogleSettingsModal'));
+const MergeOrReplaceModal = lazy(() => import('./components/modals/MergeOrReplaceModal'));
 
 // Millor posar-ho en un fitxer global.d.ts, però per compatibilitat ràpida:
 interface ElectronAPI {
@@ -559,6 +560,30 @@ const App: React.FC = () => {
       
       case 'googleSettings':
         return <GoogleSettingsModal onClose={closeModal} showToast={showToast} />;
+      case 'mergeOrReplace':
+        return (
+          <MergeOrReplaceModal
+            isOpen={true}
+            onClose={closeModal}
+            itemType={modalState.data!.itemType!}
+            onMerge={() => {
+              if (modalState.data?.itemType === 'persones') {
+                contextValue.mergePeopleGroups(modalState.data.newData);
+              } else if (modalState.data?.itemType === 'material') {
+                contextValue.addMaterialItemsFromFile(modalState.data.newData);
+              }
+              closeModal();
+            }}
+            onReplace={() => {
+              if (modalState.data?.itemType === 'persones') {
+                contextValue.replacePeopleGroups(modalState.data.newData);
+              } else if (modalState.data?.itemType === 'material') {
+                contextValue.replaceMaterialItems(modalState.data.newData);
+              }
+              closeModal();
+            }}
+          />
+        );
       default:
         return null;
     }

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useRef } from 'react';
 import { useEventData } from '../contexts/EventDataContext';
-import { PersonGroup, ModalType, ShowToastFunction } from '../types';
+import { PersonGroup, ModalType, ShowToastFunction, MaterialItem } from '../types';
 import { SaveIcon, LoadIcon, SunIcon, MoonIcon, InfoIcon, TrashIcon, GoogleIcon, SyncIcon } from '../constants';
 import { migrateData, validateMigratedData } from '../utils/dataMigration';
 
@@ -93,11 +93,9 @@ const Controls = forwardRef<any, ControlsProps>(({
           return;
         }
         const jsonData = JSON.parse(fileContent);
+        let newPeople: PersonGroup[] = [];
         if (Array.isArray(jsonData.peopleGroups)) {
-          const currentData = exportData();
-          loadData({ ...currentData, peopleGroups: jsonData.peopleGroups });
-          showToast("Dades de persones carregades correctament.", 'success');
-          setHasUnsavedChanges(true);
+          newPeople = jsonData.peopleGroups;
         } else if (Array.isArray(jsonData.people)) {
           const migratedData = migrateData({ people: jsonData.people });
           const validation = validateMigratedData(migratedData);
@@ -105,13 +103,17 @@ const Controls = forwardRef<any, ControlsProps>(({
             showToast(`Error en la migració de dades: ${validation.errors.join(', ')}`, 'error');
             return;
           }
-          const currentData = exportData();
-          loadData({ ...currentData, peopleGroups: migratedData.peopleGroups });
-          showToast("Dades de persones antigues migrades i carregades correctament.", 'success');
-          setHasUnsavedChanges(true); 
+          newPeople = migratedData.peopleGroups;
         } else {
           showToast("Error: El format del fitxer JSON de persones no és vàlid.", 'error');
+          return;
         }
+
+        onOpenModal('mergeOrReplace', {
+          itemType: 'persones',
+          newData: newPeople,
+        });
+
       } catch (error) {
         showToast(`Error en carregar les dades de persones: ${(error as Error).message}`, 'error');
       } finally {
@@ -132,7 +134,10 @@ const Controls = forwardRef<any, ControlsProps>(({
         const jsonData = JSON.parse(content);
         
         if (Array.isArray(jsonData.materialItems)) {
-          addMaterialItemsFromFile(jsonData.materialItems);
+          onOpenModal('mergeOrReplace', {
+            itemType: 'material',
+            newData: jsonData.materialItems,
+          });
         } else {
           showToast("Error: El fitxer JSON de material ha de contenir un array anomenat 'materialItems'.", 'error');
         }

--- a/src/components/modals/MergeOrReplaceModal.tsx
+++ b/src/components/modals/MergeOrReplaceModal.tsx
@@ -1,0 +1,43 @@
+import Modal from '../ui/Modal';
+
+interface MergeOrReplaceModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onMerge: () => void;
+  onReplace: () => void;
+  itemType: string; // "persones" o "material"
+}
+
+const MergeOrReplaceModal: React.FC<MergeOrReplaceModalProps> = ({ isOpen, onClose, onMerge, onReplace, itemType }) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={`Carregar dades de ${itemType}`}>
+      <div className="p-4">
+        <p className="text-gray-700 dark:text-gray-300 mb-6">
+          Vols fusionar les noves dades de {itemType} amb les existents o vols reemplaçar totes les dades actuals?
+        </p>
+        <div className="flex justify-end gap-4">
+          <button
+            onClick={onMerge}
+            className="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-md transition-colors"
+          >
+            Fusionar
+          </button>
+          <button
+            onClick={onReplace}
+            className="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded-md transition-colors"
+          >
+            Reemplaçar
+          </button>
+          <button
+            onClick={onClose}
+            className="bg-gray-300 hover:bg-gray-400 text-gray-800 font-semibold py-2 px-4 rounded-md transition-colors"
+          >
+            Cancel·lar
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default MergeOrReplaceModal;

--- a/src/hooks/useEventDataManager.ts
+++ b/src/hooks/useEventDataManager.ts
@@ -214,6 +214,32 @@ markUnsaved();
     showToast(`${itemsToAdd.length} nous articles de material afegits a l'inventari.`, 'success');
   }, [markUnsaved, showToast]);
 
+  const mergePeopleGroups = useCallback((newPeople: PersonGroup[]) => {
+    const existingNames = new Set(peopleGroupsRef.current.map(p => p.name.toLowerCase()));
+    const peopleToAdd = newPeople.filter(p => !existingNames.has(p.name.toLowerCase()));
+
+    if (peopleToAdd.length === 0) {
+      showToast("Totes les persones del fitxer ja existeixen.", 'info');
+      return;
+    }
+
+    setPeopleGroups(prev => [...prev, ...peopleToAdd].sort((a, b) => a.name.localeCompare(b.name)));
+    markUnsaved();
+    showToast(`${peopleToAdd.length} noves persones afegides.`, 'success');
+  }, [markUnsaved, showToast]);
+
+  const replacePeopleGroups = useCallback((newPeople: PersonGroup[]) => {
+    setPeopleGroups(newPeople.sort((a, b) => a.name.localeCompare(b.name)));
+    markUnsaved();
+    showToast("La llista de persones ha estat reemplaçada.", 'success');
+  }, [markUnsaved, showToast]);
+
+  const replaceMaterialItems = useCallback((newItems: MaterialItem[]) => {
+    setMaterialItems(newItems.sort((a, b) => a.name.localeCompare(b.name)));
+    markUnsaved();
+    showToast("L'inventari de material ha estat reemplaçat.", 'success');
+  }, [markUnsaved, showToast]);
+
   const getPersonGroupById = useCallback((personGroupId: string): PersonGroup | undefined => {
     return peopleGroups.find(pg => pg.id === personGroupId);
   }, [peopleGroups]);
@@ -479,6 +505,8 @@ markUnsaved();
     deleteMaterialItem,
     addMaterialItemsFromFile,
     getMaterialAvailability,
-    
+    mergePeopleGroups,
+    replacePeopleGroups,
+    replaceMaterialItems,
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,6 +158,7 @@ export type ModalType =
   | 'confirmDeleteAssignment'
   | 'googleSettings'
   | 'confirmHardReset'
+  | 'mergeOrReplace'
   | null;
 
 export interface ModalData {
@@ -218,6 +219,9 @@ export interface EventDataConteImplicits {
   deleteMaterialItem: (itemId: string) => void;
   addMaterialItemsFromFile: (newItems: MaterialItem[]) => void;
   getMaterialAvailability: (materialId: string, startDate: string, endDate: string, currentEventFrameId: string) => { available: number, total: number };
+  mergePeopleGroups: (newPeople: PersonGroup[]) => void;
+  replacePeopleGroups: (newPeople: PersonGroup[]) => void;
+  replaceMaterialItems: (newItems: MaterialItem[]) => void;
 }
 
 export type EventDataManagerReturn = Omit<EventDataConteImplicits, 'openModal' | 'showToast'>;


### PR DESCRIPTION
Adds a decision modal when you load a person or material file, allowing you to choose between merging the data with existing data or replacing it completely.

- Creates a new `MergeOrReplaceModal` component.
- Modifies `Controls.tsx` to open the modal when loading data.
- Implements the merge and replace logic in `useEventDataManager.ts`.
- Updates the documentation (`README.md` and `DEVELOPING.md`) to reflect the new functionality.