### PR TITLE
Fix: Corrigeix el comportament del botó 'Actualitza des d'assignacions'

### DIFF
--- a/src/components/tech_sheets/TechSheetForm.tsx
+++ b/src/components/tech_sheets/TechSheetForm.tsx
@@ -193,6 +193,7 @@ const TechSheetForm: React.FC<TechSheetFormProps> = ({ eventFrame }) => {
       id: generateLocalId(),
       personGroupId: '',
       roles: [],
+      isManual: true, // Marcar com a manual
     };
     setFormData(prev => ({ ...prev, technicalProviders: [...prev.technicalProviders, newProvider] }));
     markAsDirty();

--- a/src/components/tech_sheets/TechnicalPersonnelSection.tsx
+++ b/src/components/tech_sheets/TechnicalPersonnelSection.tsx
@@ -55,35 +55,49 @@ const TechnicalPersonnelSection: React.FC<TechnicalPersonnelSectionProps> = ({
               return;
             }
 
-            let updatedProviders = [...technicalProviders];
-            let rolesAddedCount = 0;
+            // Preserva proveïdors manuals i elimina els provinents d'assignacions
+            const manualProviders = technicalProviders.filter(p => p.isManual);
+
+            let newRolesCount = 0;
+            const providersFromAssignments: TechSheetProvider[] = [];
 
             confirmedAssignments.forEach((assignment: any) => {
               const personGroupId = assignment.personGroupId;
+              let provider = providersFromAssignments.find(p => p.personGroupId === personGroupId);
 
-              let providerIndex = updatedProviders.findIndex(p => p.personGroupId === personGroupId);
-              if (providerIndex === -1) {
-                const newProvider: TechSheetProvider = { id: generateLocalId(), personGroupId, roles: [] };
-                updatedProviders.push(newProvider);
-                providerIndex = updatedProviders.length - 1;
+              if (!provider) {
+                provider = {
+                  id: generateLocalId(),
+                  personGroupId,
+                  roles: [],
+                  isManual: false,
+                };
+                providersFromAssignments.push(provider);
               }
 
-              updatedProviders[providerIndex].roles.push({
+              provider.roles.push({
                 id: generateLocalId(),
+                assignmentId: assignment.id,
                 role: '',
                 quantity: 1,
                 notes: assignment.notes || '',
               });
-              rolesAddedCount++;
+              newRolesCount++;
             });
 
-            if (rolesAddedCount > 0) {
-              const updatedFormData = { ...formData, technicalProviders: updatedProviders };
+            const finalProviders = [...manualProviders, ...providersFromAssignments];
+
+            if (newRolesCount > 0) {
+              const updatedFormData = { ...formData, technicalProviders: finalProviders };
               setFormData(updatedFormData);
               addOrUpdateTechSheet(eventFrame.id, updatedFormData);
-              showToast(`${rolesAddedCount} rol(s) afegit(s) des de les assignacions. Canvis desats.`, 'success');
+              showToast(`S'ha actualitzat la llista amb ${newRolesCount} rol(s) des de les assignacions.`, 'success');
             } else {
-              showToast('No s\'ha pogut afegir cap rol nou.', 'info');
+              // Si no hi ha rols nous, potser només cal netejar els antics
+              const updatedFormData = { ...formData, technicalProviders: manualProviders };
+              setFormData(updatedFormData);
+              addOrUpdateTechSheet(eventFrame.id, updatedFormData);
+              showToast('No hi ha personal confirmat a les assignacions. S\'han eliminat les entrades anteriors.', 'info');
             }
           }}
           className="ml-2 px-2 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs font-medium shadow no-print"

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface Assignment {
 
 export interface TechSheetRoleItem {
   id: string; // ID únic per a la clau de React
+  assignmentId?: string; // ID de l'assignació original
   role: string;
   quantity: number | string; // Permetem string per a l'entrada de text
   notes?: string;
@@ -42,6 +43,7 @@ export interface TechSheetProvider {
   id: string; // ID únic per a la clau de React
   personGroupId: string; // Enllaç al PersonGroup (empresa o autònom)
   roles: TechSheetRoleItem[]; // Llista de rols que proporciona
+  isManual?: boolean; // Per identificar proveïdors afegits manualment
 }
 
 export interface TechSheetScheduleItem {


### PR DESCRIPTION
He modificat la lògica del botó 'Actualitza des d'assignacions' a les fitxes de bolo per evitar la duplicació d'entrades de personal.

La nova implementació realitza una actualització intel·ligent:
- Preserva les entrades de personal afegides manualment.
- Elimina les entrades obsoletes que provenien d'assignacions.
- Afegeix les entrades actualitzades de les assignacions confirmades.

He afegit la propietat opcional `isManual` a la interfície `TechSheetProvider` per distingir les entrades manuals. He afegit la propietat opcional `assignmentId` a `TechSheetRoleItem` per a un millor seguiment.