### PR TITLE
Fixes the macOS build by reordering the workflow steps.

### DIFF
--- a/.github/workflows/build-macos12.yml
+++ b/.github/workflows/build-macos12.yml
@@ -20,34 +20,34 @@ jobs:
       - name: 3. Instal·lació de dependències del projecte (npm)
         run: npm install
 
-      - name: 4. Compilació de l'aplicació per a macOS
-        run: npm run build:mac
-
-      - name: 4.5 Create google-credentials.json from secret
+      - name: 4. Create google-credentials.json from secret
         env:
           CREDENTIALS_JSON: ${{ secrets.GOOGLE_CREDENTIALS_JSON }}
         run: echo "$CREDENTIALS_JSON" > google-credentials.json
       
-      - name: 4.6 Create service-account.json from secret
+      - name: 5. Create service-account.json from secret
         env:
           SERVICE_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
         run: echo "$SERVICE_JSON" > service-account.json
 
-      - name: Comprova que google-credentials.json existeix i no està buit
+      - name: 6. Comprova que google-credentials.json existeix i no està buit
         run: |
           if [ ! -s google-credentials.json ]; then
             echo "El fitxer google-credentials.json està buit o no existeix!"
             exit 1
           fi
 
-      - name: 5. Creació del paquet ZIP per a macOS
+      - name: 7. Compilació de l'aplicació per a macOS
+        run: npm run build:mac
+
+      - name: 8. Creació del paquet ZIP per a macOS
         run: |
           DMG_NAME="GestorEsdevenimentsPersonal_V1.0.0-macOS-10.15+.dmg"
           ZIP_NAME="GestorEsdevenimentsPersonal_V1.0.0-macOS.zip"
           mv "dist/${DMG_NAME}" .
           zip -r "${ZIP_NAME}" "${DMG_NAME}" LICENSE README.md DEVELOPING.md "examples json"
 
-      - name: 6. Pujada del ZIP de macOS com a artefacte
+      - name: 9. Pujada del ZIP de macOS com a artefacte
         uses: actions/upload-artifact@v4
         with:
           name: GestorEsdevenimentsPersonal_V1.0.0-macOS.zip


### PR DESCRIPTION
The macOS build was failing because the application was being compiled before the `google-credentials.json` file was created. This resulted in the credentials not being included in the final application package, leading to authentication errors at runtime.

This commit reorders the steps in the `build-macos12.yml` workflow to match the working Linux workflow. The `google-credentials.json` and `service-account.json` files are now created *before* the `npm run build:mac` step. This ensures the credentials are correctly packaged within the application.

The step numbering has also been updated for clarity.