### PR TITLE
refactor(ipc): Fix TypeScript error in IPC listener cleanup

### DIFF
--- a/preload.cjs
+++ b/preload.cjs
@@ -9,8 +9,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
    },
   sendQuitConfirmedByRenderer: () => ipcRenderer.send('quit-confirmed-by-renderer-signal'),
    startGoogleAuth: () => ipcRenderer.invoke('google-auth-start'),
-  onGoogleAuthSuccess: (callback) => ipcRenderer.on('google-auth-success', callback),
-  onGoogleAuthError: (callback) => ipcRenderer.on('google-auth-error', callback),
+  onGoogleAuthSuccess: (callback) => {
+    const handler = (_event, ...args) => callback(...args);
+    ipcRenderer.on('google-auth-success', handler);
+    return () => {
+      ipcRenderer.removeListener('google-auth-success', handler);
+    };
+  },
+  onGoogleAuthError: (callback) => {
+    const handler = (_event, ...args) => callback(...args);
+    ipcRenderer.on('google-auth-error', handler);
+    return () => {
+      ipcRenderer.removeListener('google-auth-error', handler);
+    };
+  },
   getCalendarList: () => ipcRenderer.invoke('google-get-calendar-list'),
   saveGoogleConfig: (config) => ipcRenderer.invoke('save-google-config', config),
   getGoogleEvents: () => ipcRenderer.invoke('get-google-events'),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, Suspense, lazy, useRef } from 'react';
 import { HashRouter, Routes, Route } from 'react-router-dom';
-const { ipcRenderer } = window.require ? window.require('electron') : { ipcRenderer: null };
 import logger from './utils/logger';
 import { EventDataProvider } from './contexts/EventDataContext';
 import { useEventDataManager } from './hooks/useEventDataManager';
@@ -342,13 +341,15 @@ const App: React.FC = () => {
     if (window.electronAPI) {
       const onSuccess = () => showToast('Connectat a Google Calendar amb èxit!', 'success');
       const onError = (message: string) => showToast(`Error d'autenticació: ${message}`, 'error');
-      window.electronAPI.onGoogleAuthSuccess(onSuccess);
-      window.electronAPI.onGoogleAuthError(onError);
+
+      // Ara, les funcions retornen la seva pròpia funció de neteja
+      const cleanupSuccess = window.electronAPI.onGoogleAuthSuccess(onSuccess);
+      const cleanupError = window.electronAPI.onGoogleAuthError(onError);
+
+      // La funció de retorn del useEffect simplement crida a les funcions de neteja
       return () => {
-        if (ipcRenderer) {
-          ipcRenderer.removeListener('google-auth-success', onSuccess);
-          ipcRenderer.removeListener('google-auth-error', onError);
-        }
+        cleanupSuccess();
+        cleanupError();
       };
     }
   }, [showToast]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -412,8 +412,8 @@ export interface ElectronAPI {
   onConfirmQuit: (callback: () => void) => void;
   sendQuitConfirmedByRenderer: () => void;
   startGoogleAuth: () => Promise<{ success: boolean; message?: string }>;
-  onGoogleAuthSuccess: (callback: () => void) => void;
-  onGoogleAuthError: (callback: (errorMessage: string) => void) => void;
+  onGoogleAuthSuccess: (callback: () => void) => () => void;
+  onGoogleAuthError: (callback: (errorMessage: string) => void) => () => void;
   getCalendarList: () => Promise<{ success: boolean, calendars?: GoogleCalendar[], message?: string }>;
   saveGoogleConfig: (config: Partial<GoogleConfig>) => Promise<{ success: boolean, data?: GoogleConfig, message?: string }>;
   getGoogleEvents: () => Promise<{ success: boolean, events?: any[], message?: string }>;


### PR DESCRIPTION
Refactored the IPC communication for Google authentication events to fix a TypeScript type mismatch error.

The `ipcRenderer.removeListener` call in `App.tsx` was causing a compilation error because the callback function signature did not match what `removeListener` expected.

The fix involves:
1.  Moving the `ipcRenderer.on` and `ipcRenderer.removeListener` logic entirely into `preload.cjs`.
2.  The exposed API functions (`onGoogleAuthSuccess`, `onGoogleAuthError`) now return a cleanup function.
3.  `App.tsx` is simplified to use the returned cleanup function within the `useEffect` hook, removing its direct dependency on `ipcRenderer`.
4.  Updated `src/types.ts` to reflect the new API contract.

This change not only resolves the build error but also improves code quality by better enforcing Electron's context isolation principle.