### PR TITLE
refactor(material): Implement advanced material editing with full pro…

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -528,6 +528,15 @@ La funció implementa una lògica granular per garantir un càlcul d'estoc prec�
 -   Mostra el resultat com a text informatiu (`infoText`) al component `TechSheetField`.
 -   Aplica una classe CSS d'error al camp de quantitat si `need.quantity > availability.available`.
 
+#### Propagació de Canvis i Font de Veritat
+
+Per garantir la consistència de les dades a tota l'aplicació, s'ha implementat un sistema de propagació de canvis des de l'inventari mestre:
+
+-   **Edició Centralitzada:** Qualsevol propietat d'un ítem de material es pot editar ara des de la vista de "Material".
+-   **Bloqueig de UI:** En desar un canvi, la UI es bloqueja temporalment per garantir que l'operació sigui atòmica.
+-   **Propagació Automàtica:** L'acció `updateMaterialItem` a `eventDataStore` no només actualitza l'ítem a la llista `materialItems`, sinó que també itera sobre tots els `eventFrames` i les seves `techSheet`. Si troba una necessitat (`NeedItem`) que utilitza el material modificat (comparant `materialItemId`), actualitza automàticament les seves propietats derivades (com `description` i `origin`).
+-   **Font de Veritat:** Per reforçar aquest concepte, a `NeedsList.tsx`, els camps "Descripció" i "Origen" d'una necessitat es tornen de només lectura (`readOnly`) si estan vinculats a un ítem de l'inventari, evitant edicions manuals que podrien crear inconsistències.
+
 ### 5.4. Detecció de Conflictes d'Assignació
 
 Aquesta lògica, similar al control d'estoc, preveu que una persona sigui assignada a dos llocs alhora.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ const App: React.FC = () => {
   }, [hasUnsavedChanges]);
 
   const isSyncing = useEventDataStore(state => state.isSyncing);
+  const isUpdatingMaterial = useEventDataStore(state => state.isUpdatingMaterial);
   const syncProgress = useEventDataStore(state => state.syncProgress);
   const canUndo = useStore(useEventDataStore.temporal, state => state.pastStates.length > 0);
   const canRedo = useStore(useEventDataStore.temporal, state => state.futureStates.length > 0);
@@ -906,6 +907,15 @@ const App: React.FC = () => {
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
               </svg>
               <p className="text-white text-lg">{loadingOverlayMessage || "Processant..."}</p>
+            </div>
+          )}
+          {isUpdatingMaterial && (
+            <div className="fixed inset-0 bg-gray-900 bg-opacity-75 flex flex-col justify-center items-center z-[9999]" aria-live="assertive" role="alert">
+              <svg className="animate-spin h-10 w-10 text-white mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              <p className="text-white text-lg">Actualitzant material a tota l'aplicació...</p>
             </div>
           )}
           </div>

--- a/src/components/MaterialDisplay.tsx
+++ b/src/components/MaterialDisplay.tsx
@@ -190,6 +190,7 @@ const MaterialDisplay: React.FC<MaterialDisplayProps> = ({ showToast }) => {
             onCancel={editingItem ? resetForm : undefined}
             submitButtonText={editingItem ? 'Actualitzar' : 'Afegir'}
             categories={categories}
+            materialItems={materialItems}
           />
         </div>
 

--- a/src/components/forms/MaterialForm.tsx
+++ b/src/components/forms/MaterialForm.tsx
@@ -9,7 +9,8 @@ export interface MaterialFormProps {
   onSubmit: (data: Omit<MaterialItem, 'id'>) => void;
   onCancel?: () => void;
   submitButtonText?: string;
-  categories?: string[]; // Llista de categories per a l'autocompletat
+  categories?: string[];
+  materialItems?: MaterialItem[]; // Llista completa per a la validació
 }
 
 const MaterialForm: React.FC<MaterialFormProps> = ({
@@ -18,6 +19,7 @@ const MaterialForm: React.FC<MaterialFormProps> = ({
   onCancel,
   submitButtonText = 'Desar',
   categories = [],
+  materialItems = [],
 }) => {
   // Estats interns per als camps del formulari
   const [name, setName] = useState('');
@@ -50,7 +52,17 @@ const MaterialForm: React.FC<MaterialFormProps> = ({
   // Funció de validació
   const validate = (): boolean => {
     const newErrors: { [key: string]: string } = {};
-    if (!name.trim()) newErrors.name = "El nom és obligatori.";
+    if (!name.trim()) {
+        newErrors.name = "El nom és obligatori.";
+    } else {
+        const isDuplicate = materialItems.some(item =>
+            item.name.toLowerCase() === name.trim().toLowerCase() &&
+            item.id !== initialData?.id
+        );
+        if (isDuplicate) {
+            newErrors.name = "Ja existeix un material amb aquest nom.";
+        }
+    }
     if (!category.trim()) newErrors.category = "La categoria és obligatòria.";
     if (stock < 0) newErrors.stock = "L'estoc no pot ser negatiu.";
     setErrors(newErrors);
@@ -84,8 +96,6 @@ const MaterialForm: React.FC<MaterialFormProps> = ({
             onChange={e => setName(e.target.value)}
             className={commonInputClass}
             required
-            // Si el nom ve de initialData (des de la fitxa tècnica), no es pot editar
-            disabled={!!initialData?.name}
           />
         </Tooltip>
         {errors.name && <p className="text-red-500 text-xs mt-1">{errors.name}</p>}

--- a/src/components/tech_sheets/NeedsList.tsx
+++ b/src/components/tech_sheets/NeedsList.tsx
@@ -94,6 +94,7 @@ const NeedsList: React.FC<NeedsListProps> = ({
                   onChange={e => onListChange(listName, index, 'description', e.target.value)}
                   suggestions={materialSuggestions}
                   infoText={availabilityInfo}
+                  readOnly={!!selectedMaterial}
                 />
                 {selectedMaterial && selectedMaterial.notes && (
                   <p className="no-print text-xs italic text-gray-500 dark:text-gray-400 mt-1">

--- a/src/stores/eventDataStore.ts
+++ b/src/stores/eventDataStore.ts
@@ -59,6 +59,7 @@ interface EventDataState {
     googleEvents: any[];
     hasUnsavedChanges: boolean;
     isSyncing: boolean;
+    isUpdatingMaterial: boolean;
     syncProgress: SyncProgressState;
     dataRepairInfo: { fixes: any[], repairedData: AppData } | null;
     filterUIEventFrame: string | null;
@@ -119,6 +120,7 @@ interface EventDataActions {
     replaceMaterialItems: (newItems: MaterialItem[]) => void;
     _applyDataToState: (data: AppData) => void;
     clearDataRepairInfo: () => void;
+    setIsUpdatingMaterial: (isUpdating: boolean) => void;
 }
 
 const initialState: EventDataState = {
@@ -128,6 +130,7 @@ const initialState: EventDataState = {
     googleEvents: [],
     hasUnsavedChanges: false,
     isSyncing: false,
+    isUpdatingMaterial: false,
     syncProgress: { current: 0, total: 0, message: '', visible: false },
     dataRepairInfo: null,
     filterUIEventFrame: null,
@@ -148,6 +151,8 @@ export const useEventDataStore = create<EventDataState & EventDataActions>()(
     immer(
       (set, get) => ({
         ...initialState,
+
+        setIsUpdatingMaterial: (isUpdating: boolean) => set({ isUpdatingMaterial: isUpdating }),
 
         clearDataRepairInfo: () => set({ dataRepairInfo: null }),
 
@@ -451,7 +456,41 @@ export const useEventDataStore = create<EventDataState & EventDataActions>()(
         return newItem;
     },
     updateMaterialItem: (updatedItem: MaterialItem) => {
-        set((state: EventDataState) => ({ materialItems: state.materialItems.map((item: MaterialItem) => item.id === updatedItem.id ? updatedItem : item).sort((a: MaterialItem,b: MaterialItem) => a.name.localeCompare(b.name)), hasUnsavedChanges: true }));
+        const { setIsUpdatingMaterial } = get();
+        try {
+            setIsUpdatingMaterial(true);
+            set(state => {
+                // 1. Actualitzar l'ítem mestre
+                state.materialItems = state.materialItems.map(item =>
+                    item.id === updatedItem.id ? updatedItem : item
+                ).sort((a, b) => a.name.localeCompare(b.name));
+
+                // 2. Propagar canvis a tota l'app
+                const needsKeys: (keyof TechSheetData)[] = [
+                    'lighting', 'sound', 'video', 'machinery', 'rentals', 'otherEquipment',
+                    'electrical', 'structures', 'platforms', 'consumables', 'curtains', 'transport'
+                ];
+
+                state.eventFrames.forEach(eventFrame => {
+                    if (!eventFrame.techSheet) return;
+
+                    needsKeys.forEach(key => {
+                        const section = eventFrame.techSheet![key];
+                        if (section && typeof section === 'object' && 'status' in section && section.status === 'yes' && 'data' in section && section.data && Array.isArray(section.data.needs)) {
+                            section.data.needs.forEach((needItem: NeedItem) => {
+                                if (needItem.materialItemId === updatedItem.id) {
+                                    needItem.description = updatedItem.name;
+                                    needItem.origin = updatedItem.location;
+                                }
+                            });
+                        }
+                    });
+                });
+                state.hasUnsavedChanges = true;
+            });
+        } finally {
+            setIsUpdatingMaterial(false);
+        }
     },
     deleteMaterialItem: (itemId: string) => {
         set((state: EventDataState) => ({ materialItems: state.materialItems.filter((item: MaterialItem) => item.id !== itemId), hasUnsavedChanges: true }));


### PR DESCRIPTION
…pagation

This commit introduces a robust system for editing material items.

Key changes:
- The material form now allows editing all properties of an item, including the name, with validation to prevent duplicate names.
- A new UI locking mechanism has been implemented. When an item is updated, the UI is blocked with a full-screen overlay and a spinner to ensure data integrity during the process.
- The `updateMaterialItem` action in the data store now propagates any changes to an item (like name or location) to all the tech sheets where that item is used. This ensures data consistency across the entire application.
- The tech sheet's needs list now enforces the inventory as the single source of truth by making the description and origin fields read-only when an item is linked to the inventory.
- The documentation has been updated to reflect these new features.